### PR TITLE
[SonarQube] Exporting mutable 'let' binding, use 'const' instead.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { LogLevel, SapphireClient } from '@sapphire/framework';
 import 'dotenv/config';
 import '@sentry/tracing';
 
-export let client: SapphireClient;
+let internalClient: SapphireClient;
 
 export function startBot(): { client: SapphireClient } {
 	Sentry.init({
@@ -13,14 +13,14 @@ export function startBot(): { client: SapphireClient } {
 		tracesSampleRate: 1.0
 	});
 
-	client = new SapphireClient({
+	internalClient = new SapphireClient({
 		intents: [GatewayIntentBits.Guilds],
 		logger: { level: LogLevel.Info }
 	});
 
 	/* istanbul ignore next */
-	client.once('ready', () => {
-		console.log(`✅ Bot is online as ${client.user?.tag}!`);
+	internalClient.once('ready', () => {
+		console.log(`✅ Bot is online as ${internalClient.user?.tag}!`);
 	});
 
 	/* istanbul ignore else */
@@ -28,7 +28,7 @@ export function startBot(): { client: SapphireClient } {
 		attachErrorHandlers();
 
 		/* istanbul ignore next */
-		client
+		internalClient
 			.login(process.env.DISCORD_TOKEN)
 			.catch((error) => {
 				Sentry.captureException(error);
@@ -36,18 +36,18 @@ export function startBot(): { client: SapphireClient } {
 			});
 	}
 
-	return { client };
+	return { client: internalClient };
 }
 
 export function attachErrorHandlers(): void {
 	process.on('unhandledRejection', (reason) => {
 		Sentry.captureException(reason);
-		client.logger.error('Unhandled Rejection:', reason);
+		internalClient.logger.error('Unhandled Rejection:', reason);
 	});
 
 	process.on('uncaughtException', (error) => {
 		Sentry.captureException(error);
-		client.logger.error('Uncaught Exception:', error);
+		internalClient.logger.error('Uncaught Exception:', error);
 	});
 }
 

--- a/src/tests/coverage.spec.ts
+++ b/src/tests/coverage.spec.ts
@@ -28,26 +28,20 @@ describe('Coverage Utility', () => {
 
 	beforeEach(() => {
 		jest.spyOn(SapphireClient.prototype, 'login').mockImplementation(() => Promise.resolve('mock-token'));
-
-		// Suppress logger output during tests
 		jest.spyOn(console, 'error').mockImplementation(() => {});
 	});
 
 	it('simulates a handled unhandledRejection', () => {
-		const { client } = startBot() ?? {};
-		if (!client) throw new Error('Client not initialized');
-		client.logger = mockLogger;
-
+		const { client } = startBot();
+		(client as any).logger = mockLogger; // Override readonly for test
 		const testReason = new Error('Simulated rejection');
 		(process as NodeJS.EventEmitter).emit('unhandledRejection', testReason);
 		expect(mockLogger.error).toHaveBeenCalledWith('Unhandled Rejection:', testReason);
 	});
 
 	it('simulates a handled uncaughtException', () => {
-		const { client } = startBot() ?? {};
-		if (!client) throw new Error('Client not initialized');
-		client.logger = mockLogger;
-
+		const { client } = startBot();
+		(client as any).logger = mockLogger; // Override readonly for test
 		const testError = new Error('Simulated exception');
 		process.emit('uncaughtException', testError);
 		expect(mockLogger.error).toHaveBeenCalledWith('Uncaught Exception:', testError);

--- a/src/tests/sentry.spec.ts
+++ b/src/tests/sentry.spec.ts
@@ -32,8 +32,7 @@ describe('Sentry Integration Tests', () => {
 			process.env.NODE_ENV = 'test';
 
 			const index = require('../index');
-			index.startBot();
-			const client = index.client;
+			const { client } = index.startBot();
 
 			index.attachErrorHandlers();
 			client.logger = mockLogger;
@@ -57,8 +56,7 @@ describe('Sentry Integration Tests', () => {
 
 			const Sentry = require('@sentry/node');
 			const index = require('../index');
-			index.startBot(); // ← This initializes `client`
-			const client = index.client;
+			const { client } = index.startBot();
 
 			index.attachErrorHandlers();
 			client.logger = mockLogger;
@@ -81,8 +79,7 @@ describe('Sentry Integration Tests', () => {
 
 			const Sentry = require('@sentry/node');
 			const index = require('../index');
-			index.startBot(); // initialize client
-			const client = index.client;
+			const { client } = index.startBot();
 
 			index.attachErrorHandlers();
 			client.logger = mockLogger;


### PR DESCRIPTION
Fixes #80