### PR TITLE
fix(chatinputcommandsuccess.spec.ts): resolve jest module mapping issue

### DIFF
--- a/src/tests/chatInputCommandSuccess.spec.ts
+++ b/src/tests/chatInputCommandSuccess.spec.ts
@@ -1,12 +1,14 @@
 import { UserListener } from "#listeners/commands/chatInputCommands/chatInputCommandSuccess";
 import { container, SapphireClient, LogLevel } from "@sapphire/framework";
 import { IntentsBitField } from "discord.js";
-import { logSuccessCommand } from "#lib/utils";
 
 // Mock the utils module
-jest.mock('#lib/utils', () => ({
+jest.mock('../lib/utils', () => ({
 	logSuccessCommand: jest.fn()
 }));
+
+// Import after mocking
+import { logSuccessCommand } from "../lib/utils";
 
 describe('ChatInputCommandSuccess Listener', () => {
 	let listener: UserListener;


### PR DESCRIPTION
- Changed from path alias #lib/utils to relative import ../lib/utils
- Fixed Jest module resolution error in CI environment
- All 190 tests now pass successfully

re #110