### PR TITLE
fix: update CI workflow to test feature branches instead of target branch

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Run Unit Tests
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches: [ develop ]
     types: [ opened, synchronize, reopened ]
 
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -35,4 +37,11 @@ jobs:
         shell: bash
 
       - name: Run Tests
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          MONGO_USERNAME: test_user
+          MONGO_PASSWORD: test_password
+          MONGO_HOST: test_host
+          NODE_ENV: test
+          ENABLE_TEST_ERROR_HANDLERS: true
         run: pnpm run test


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Actions workflow to properly test feature branches instead of the target branch.

## Changes
- Change `pull_request_target` to `pull_request` to run in feature branch context
- Add `ref: github.head_ref` to explicitly checkout feature branch code  
- Add missing environment variables for proper test execution

## Why This Fix is Needed
The current workflow uses `pull_request_target` which runs in the context of the target branch (develop/main), meaning it tests the target branch code instead of the actual changes being submitted in the PR. This causes CI to test outdated code that doesn't include the changes from the feature branch.

## Impact
This ensures that CI tests the actual changes being submitted in PRs, which is critical for validating that Jest module resolution fixes and other code changes work correctly in the CI environment.