### PR TITLE
fix: remove explicit ref from checkout to use default PR behavior

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
**Critical Fix for CI Workflow**

## Issue
The workflow was using `ref: ${{ github.head_ref }}` which is empty for `pull_request` events, causing the workflow to still check out the wrong branch.

## Solution
Remove the explicit ref parameter to allow `actions/checkout@v4` to use its default behavior, which correctly checks out the PR head commit for `pull_request` events.

## Impact
This ensures CI actually tests the feature branch code instead of the target branch code.