### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,8 @@
 name: Run Unit Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/4](https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since there is only one job in this workflow, you can add the block at either the root level (applies to all jobs) or at the job level (applies only to the `test` job). The minimal required permission for running unit tests is typically `contents: read`, which allows the workflow to read the repository contents but not modify them. 

The best way to fix this is to add the following block:
```yaml
permissions:
  contents: read
```
You should add this block at the top level of the workflow, just after the `name` and before the `on` block (recommended), or inside the `test` job definition. This ensures the workflow runs with least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
