### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -16,6 +16,8 @@ jobs:
       github.event_name == 'pull_request' && github.base_ref == 'main'
     name: SonarQube Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/3](https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/3)

To fix the problem, we need to add a `permissions` block to the `sonarcloud` job in `.github/workflows/security-checks.yml`. The minimal starting point is `contents: read`, which is sufficient for most analysis jobs that only need to read the repository contents. If the job requires additional permissions (e.g., to create issues or comments), those can be added, but based on the steps shown, only read access to contents is needed. The change should be made by adding the following block under the `sonarcloud:` job definition, at the same indentation level as `runs-on`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
