### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting-checks.yml
+++ b/.github/workflows/linting-checks.yml
@@ -1,4 +1,6 @@
 name: Run Lint Code Check
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/2](https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and run linting, it only requires `contents: read` permission. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `lint` job). The best practice is to set it at the workflow level unless a job needs different permissions. To implement the fix, add the following block after the `name:` line and before the `on:` block in `.github/workflows/linting-checks.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
