### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube-issues-to-github.yml
+++ b/.github/workflows/sonarqube-issues-to-github.yml
@@ -1,4 +1,7 @@
 name: Sync SonarQube Issues to GitHub
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/1](https://github.com/dustin-lennon/NightScoutMongoBackup/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to only the permissions required. In this case, the workflow needs to read repository contents (for checkout) and create issues (for the GitHub issues step). Therefore, set `contents: read` and `issues: write` at the workflow level, which will apply to all jobs unless overridden. This change should be made at the top level of the YAML file, immediately after the `name:` field and before the `on:` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
