### PR TITLE
fix: Update SonarCloud action to use sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -73,14 +73,15 @@ jobs:
           poetry run pytest -v --cov=src --cov-report=xml:coverage.xml
 
       - name: Run SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v5
+        uses: sonarsource/sonarqube-scan-action@v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
         with:
+          projectBaseDir: .
           args: >
             -Dsonar.projectKey=dustin-lennon_NightScoutMongoBackup
             -Dsonar.organization=dustin-lennon
-            -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.sources=src
             -Dsonar.tests=tests
             -Dsonar.test.inclusions=tests/**/*.py


### PR DESCRIPTION
## Description
This PR updates the SonarCloud GitHub Action workflow to use the recommended `sonarqube-scan-action` instead of the deprecated `sonarcloud-github-action`.

## Changes
- Replace deprecated `SonarSource/sonarcloud-github-action@v5` with `sonarsource/sonarqube-scan-action@v5.0.0`
- Add `SONAR_HOST_URL` as environment variable
- Add `projectBaseDir` input parameter
- Remove redundant `sonar.host.url` from args (now using env var)

## Related Issues
Fixes the deprecation warning and should help resolve the 'Project not found' error when `SONAR_TOKEN` is properly configured.

## Testing
- [x] Workflow file syntax validated
- [ ] PR workflow will be tested when this PR is opened