### PR TITLE
fix: add .js extension to semantic-release plugin path

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
       }
     ],
     [
-      "./scripts/semantic-release-python",
+      "./scripts/semantic-release-python.js",
       {
         "botVersionFile": "src/nightscout_backup_bot/__init__.py",
         "apiVersionFile": "src/nightscout_backup_bot/api/__init__.py",


### PR DESCRIPTION
## Fix

Fixes the semantic-release workflow error where it couldn't find the custom Python plugin module.

**Issue**: The plugin path in  was missing the  extension, causing semantic-release to fail with:
```
Error: Cannot find module './scripts/semantic-release-python'
```

**Solution**: Updated the path from `./scripts/semantic-release-python` to `./scripts/semantic-release-python.js`

This allows semantic-release to correctly resolve and load the custom plugin during the release workflow.