### PR TITLE
fix: restrict CodeQL analysis to PRs targeting develop only

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@ name: CodeQL Analysis
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main, develop ]
+    branches: [ develop ]
 
 jobs:
   analyze:


### PR DESCRIPTION
CodeQL scan should only run when merging branches into develop, not when merging develop into main. This prevents CodeQL from blocking releases.