### PR TITLE
fix: Use resolved absolute paths for load_dotenv calls

### DIFF
--- a/src/nightscout_backup_bot/config.py
+++ b/src/nightscout_backup_bot/config.py
@@ -23,10 +23,10 @@ if node_env == "production":
     default_env_file = Path(DEFAULT_ENV_FILE)
     # Always load .env first (base/common variables) if it exists
     if default_env_file.exists():
-        load_dotenv(dotenv_path=DEFAULT_ENV_FILE, override=False)
+        load_dotenv(dotenv_path=str(default_env_file.resolve()), override=False)
     # Then load .env.production if it exists (production-specific overrides)
     if prod_env_file.exists():
-        load_dotenv(dotenv_path=PROD_ENV_FILE, override=True)
+        load_dotenv(dotenv_path=str(prod_env_file.resolve()), override=True)
         env_file = PROD_ENV_FILE  # Use for Pydantic Settings
 else:
     # Load .env file or .env.vault (if DOTENV_KEY is set)


### PR DESCRIPTION
## Problem

The deployment was still experiencing `FileNotFoundError` with empty string paths when loading environment files. While the file existence check was added, there was a path resolution mismatch between the `Path.exists()` check and the `load_dotenv()` call.

## Solution

Updated the code to use `Path.resolve()` and convert to string before passing to `load_dotenv`. This ensures:
- Consistent path resolution regardless of working directory
- Absolute paths are used, preventing relative path resolution issues
- The same path used for existence check is used for loading

## Changes

- Changed `load_dotenv(dotenv_path=DEFAULT_ENV_FILE, ...)` to use `str(default_env_file.resolve())`
- Changed `load_dotenv(dotenv_path=PROD_ENV_FILE, ...)` to use `str(prod_env_file.resolve())`
- Ensures the Path object used for existence check matches the path passed to load_dotenv

## Testing

- Pre-commit hooks passed (black, ruff, mypy)
- Fix addresses the path resolution issue that was causing empty string paths in FileNotFoundError