### PR TITLE
fix: Only load .env.production in production, skip .env

### DIFF
--- a/src/nightscout_backup_bot/config.py
+++ b/src/nightscout_backup_bot/config.py
@@ -19,17 +19,17 @@ env_file = DEFAULT_ENV_FILE
 
 # Load environment variables with proper precedence
 if node_env == "production":
+    # In production, dotenv-vault creates .env.production via "dotenv-vault pull production"
+    # Only load .env.production, not .env
     prod_env_file = Path(PROD_ENV_FILE)
-    default_env_file = Path(DEFAULT_ENV_FILE)
-    # Always load .env first (base/common variables) if it exists
-    if default_env_file.exists():
-        load_dotenv(dotenv_path=str(default_env_file.resolve()), override=False)
-    # Then load .env.production if it exists (production-specific overrides)
     if prod_env_file.exists():
         load_dotenv(dotenv_path=str(prod_env_file.resolve()), override=True)
         env_file = PROD_ENV_FILE  # Use for Pydantic Settings
+    # If .env.production doesn't exist, let dotenv-vault handle it (it will use .env.vault if DOTENV_KEY is set)
+    else:
+        load_dotenv()
 else:
-    # Load .env file or .env.vault (if DOTENV_KEY is set)
+    # In development, load .env file or .env.vault (if DOTENV_KEY is set)
     load_dotenv()
 
 


### PR DESCRIPTION
## Problem

In production, the code was trying to load both `.env` and `.env.production`. However, since dotenv-vault creates `.env.production` via `dotenv-vault pull production`, we should only load `.env.production` in production mode, not `.env`.

## Solution

Updated the production environment loading logic to:
- Only load `.env.production` if it exists (created by dotenv-vault)
- Skip loading `.env` entirely in production
- Fall back to `load_dotenv()` if `.env.production` doesn't exist (allows dotenv-vault to handle `.env.vault` if `DOTENV_KEY` is set)

## Changes

- Removed the logic that loads `.env` first in production mode
- Production now only loads `.env.production` (matching dotenv-vault's behavior)
- Development mode unchanged (still uses `.env` or `.env.vault`)

## Testing

- Pre-commit hooks passed (black, ruff, mypy)
- Aligns with dotenv-vault's production workflow where `dotenv-vault pull production` creates `.env.production`