### PR TITLE
fix: resolve nightly backup task silently dying due to ZoneInfo TypeError

### DIFF
--- a/src/nightscout_backup_bot/bot.py
+++ b/src/nightscout_backup_bot/bot.py
@@ -16,6 +16,20 @@ from nightscout_backup_bot.utils.pm2_process_manager import PM2ProcessManager
 logger = StructuredLogger(__name__)
 
 
+def _get_backup_time_utc(hour: int, minute: int) -> datetime.time:
+    """Convert an Eastern backup time to UTC, correctly resolving the current DST offset.
+
+    ZoneInfo cannot determine the UTC offset from a bare datetime.time (no date = no DST
+    context), so passing ZoneInfo to tasks.loop(time=...) causes a TypeError inside disnake's
+    internal time comparison and silently kills the task before it ever fires.  Using a full
+    datetime here gives ZoneInfo the date it needs to pick EST vs. EDT correctly.
+    """
+    eastern = zoneinfo.ZoneInfo("America/New_York")
+    today = datetime.date.today()
+    dt_eastern = datetime.datetime(today.year, today.month, today.day, hour, minute, tzinfo=eastern)
+    return dt_eastern.astimezone(datetime.UTC).timetz()
+
+
 class NightScoutBackupBot(commands.Bot):
     """Custom bot class for NightScout backup operations."""
 
@@ -55,6 +69,7 @@ class NightScoutBackupBot(commands.Bot):
                     "Nightly backup task started",
                     hour=settings.backup_hour,
                     minute=settings.backup_minute,
+                    utc_time=str(self.nightly_backup.time[0]) if self.nightly_backup.time else None,
                 )
 
     async def on_slash_command(self, inter: disnake.ApplicationCommandInteraction["NightScoutBackupBot"]) -> None:
@@ -81,13 +96,7 @@ class NightScoutBackupBot(commands.Bot):
             user_id=interaction.author.id,
         )
 
-    @tasks.loop(
-        time=datetime.time(
-            hour=settings.backup_hour,
-            minute=settings.backup_minute,
-            tzinfo=zoneinfo.ZoneInfo("America/New_York"),
-        )
-    )
+    @tasks.loop(time=_get_backup_time_utc(settings.backup_hour, settings.backup_minute))
     async def nightly_backup(self) -> None:
         """Execute nightly backup at scheduled time."""
         try:

--- a/src/nightscout_backup_bot/bot.py
+++ b/src/nightscout_backup_bot/bot.py
@@ -1,12 +1,13 @@
 """Discord bot initialization and setup."""
 
+import asyncio
 import datetime
 import zoneinfo
 from collections.abc import Awaitable, Callable
 from typing import cast, override
 
 import disnake
-from disnake.ext import commands, tasks
+from disnake.ext import commands
 
 from nightscout_backup_bot.config import settings
 from nightscout_backup_bot.logging_config import StructuredLogger, setup_logging
@@ -16,25 +17,12 @@ from nightscout_backup_bot.utils.pm2_process_manager import PM2ProcessManager
 logger = StructuredLogger(__name__)
 
 
-def _get_backup_time_utc(hour: int, minute: int) -> datetime.time:
-    """Convert an Eastern backup time to UTC, correctly resolving the current DST offset.
-
-    ZoneInfo cannot determine the UTC offset from a bare datetime.time (no date = no DST
-    context), so passing ZoneInfo to tasks.loop(time=...) causes a TypeError inside disnake's
-    internal time comparison and silently kills the task before it ever fires.  Using a full
-    datetime here gives ZoneInfo the date it needs to pick EST vs. EDT correctly.
-    """
-    eastern = zoneinfo.ZoneInfo("America/New_York")
-    today = datetime.date.today()
-    dt_eastern = datetime.datetime(today.year, today.month, today.day, hour, minute, tzinfo=eastern)
-    return dt_eastern.astimezone(datetime.UTC).timetz()
-
-
 class NightScoutBackupBot(commands.Bot):
     """Custom bot class for NightScout backup operations."""
 
     backup_service: BackupService
     pm2_process_manager: PM2ProcessManager
+    _scheduler_task: "asyncio.Task[None] | None"
 
     def __init__(self) -> None:
         """Initialize the bot."""
@@ -51,6 +39,7 @@ class NightScoutBackupBot(commands.Bot):
 
         self.backup_service = BackupService()
         self.pm2_process_manager = PM2ProcessManager()
+        self._scheduler_task = None
 
     async def on_ready(self) -> None:
         """Called when bot is ready."""
@@ -61,15 +50,14 @@ class NightScoutBackupBot(commands.Bot):
             guilds=len(self.guilds),
         )
 
-        # Start nightly backup task if enabled
+        # Start nightly backup scheduler if enabled
         if settings.enable_nightly_backup:
-            if not self.nightly_backup.is_running():
-                _ = self.nightly_backup.start()
+            if self._scheduler_task is None or self._scheduler_task.done():
+                self._scheduler_task = asyncio.create_task(self._nightly_backup_scheduler())
                 logger.info(
-                    "Nightly backup task started",
+                    "Nightly backup scheduler started",
                     hour=settings.backup_hour,
                     minute=settings.backup_minute,
-                    utc_time=str(self.nightly_backup.time[0]) if self.nightly_backup.time else None,
                 )
 
     async def on_slash_command(self, inter: disnake.ApplicationCommandInteraction["NightScoutBackupBot"]) -> None:
@@ -96,9 +84,37 @@ class NightScoutBackupBot(commands.Bot):
             user_id=interaction.author.id,
         )
 
-    @tasks.loop(time=_get_backup_time_utc(settings.backup_hour, settings.backup_minute))
+    async def _nightly_backup_scheduler(self) -> None:
+        """Sleep until the next configured Eastern time, then run the backup — forever.
+
+        Using datetime.datetime.now(ZoneInfo(...)) gives ZoneInfo a concrete date so it can
+        resolve EST vs. EDT correctly.  The offset is recomputed on every iteration, meaning
+        DST transitions are handled automatically without a bot restart.
+        """
+        await self.wait_until_ready()
+        eastern = zoneinfo.ZoneInfo("America/New_York")
+        while True:
+            now = datetime.datetime.now(eastern)
+            target = now.replace(
+                hour=settings.backup_hour,
+                minute=settings.backup_minute,
+                second=0,
+                microsecond=0,
+            )
+            if target <= now:
+                target += datetime.timedelta(days=1)
+
+            wait_seconds = (target - now).total_seconds()
+            logger.debug(
+                "Nightly backup sleeping until next run",
+                next_run_eastern=str(target),
+                wait_seconds=round(wait_seconds),
+            )
+            await asyncio.sleep(wait_seconds)
+            await self.nightly_backup()
+
     async def nightly_backup(self) -> None:
-        """Execute nightly backup at scheduled time."""
+        """Execute nightly backup."""
         try:
             logger.info("Starting nightly backup")
 
@@ -148,11 +164,6 @@ class NightScoutBackupBot(commands.Bot):
 
         except Exception as e:
             logger.error("Nightly backup failed", error=str(e))
-
-    @nightly_backup.before_loop
-    async def before_nightly_backup(self) -> None:
-        """Wait until bot is ready before starting the scheduled backup loop."""
-        await self.wait_until_ready()
 
     def load_cogs(self) -> None:
         """Load all cogs."""

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -1,13 +1,26 @@
 """Unit tests for bot initialization and configuration."""
 
+import datetime
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import disnake
 import pytest
 
-from nightscout_backup_bot.bot import NightScoutBackupBot, create_bot
+from nightscout_backup_bot.bot import NightScoutBackupBot, _get_backup_time_utc, create_bot
 from nightscout_backup_bot.config import settings
+
+
+def test_get_backup_time_utc_returns_utc_aware_time() -> None:
+    """_get_backup_time_utc must return a UTC-aware time compatible with disnake tasks.loop."""
+    result = _get_backup_time_utc(2, 0)
+
+    assert isinstance(result, datetime.time)
+    assert result.tzinfo == datetime.UTC, "Result must be UTC-aware (not ZoneInfo)"
+    assert result.utcoffset() == datetime.timedelta(0), "UTC offset must be zero"
+    # 2 AM Eastern is either 6 AM or 7 AM UTC depending on DST
+    assert result.hour in (6, 7), f"Expected 6 or 7 UTC for 2 AM Eastern, got {result.hour}"
+    assert result.minute == 0
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -1,26 +1,14 @@
 """Unit tests for bot initialization and configuration."""
 
-import datetime
+import asyncio
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import disnake
 import pytest
 
-from nightscout_backup_bot.bot import NightScoutBackupBot, _get_backup_time_utc, create_bot
+from nightscout_backup_bot.bot import NightScoutBackupBot, create_bot
 from nightscout_backup_bot.config import settings
-
-
-def test_get_backup_time_utc_returns_utc_aware_time() -> None:
-    """_get_backup_time_utc must return a UTC-aware time compatible with disnake tasks.loop."""
-    result = _get_backup_time_utc(2, 0)
-
-    assert isinstance(result, datetime.time)
-    assert result.tzinfo == datetime.UTC, "Result must be UTC-aware (not ZoneInfo)"
-    assert result.utcoffset() == datetime.timedelta(0), "UTC offset must be zero"
-    # 2 AM Eastern is either 6 AM or 7 AM UTC depending on DST
-    assert result.hour in (6, 7), f"Expected 6 or 7 UTC for 2 AM Eastern, got {result.hour}"
-    assert result.minute == 0
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +34,9 @@ async def test_bot_initialization() -> None:
     # Check backup service is initialized
     assert bot.backup_service is not None, "Backup service should be initialized"
 
+    # Scheduler task should not be running yet
+    assert bot._scheduler_task is None
+
 
 @pytest.mark.asyncio
 async def test_create_bot_function() -> None:
@@ -59,28 +50,54 @@ async def test_create_bot_function() -> None:
 
 @pytest.mark.asyncio
 async def test_bot_on_ready_event(caplog: pytest.LogCaptureFixture) -> None:
-    """Test on_ready event handler."""
+    """Test on_ready starts the nightly backup scheduler when enabled."""
     bot = NightScoutBackupBot()
 
-    # Mock the user property and guilds
     mock_user = MagicMock()
     mock_user.id = 123456789
     mock_user.__str__ = MagicMock(return_value="TestBot#1234")  # type: ignore[method-assign]
 
     mock_guilds = [MagicMock(), MagicMock()]
 
-    with patch.object(type(bot), "user", new=mock_user), patch.object(type(bot), "guilds", new=mock_guilds):
-        # Mock nightly backup task
-        bot.nightly_backup = MagicMock()  # type: ignore[method-assign]
-        bot.nightly_backup.is_running.return_value = False
-        bot.nightly_backup.start = MagicMock()
+    mock_task = MagicMock(spec=asyncio.Task)
 
-        # Call on_ready
+    with (
+        patch.object(type(bot), "user", new=mock_user),
+        patch.object(type(bot), "guilds", new=mock_guilds),
+        patch("nightscout_backup_bot.bot.asyncio.create_task", return_value=mock_task) as mock_create_task,
+    ):
         await bot.on_ready()
 
-        # Verify nightly backup was started if enabled
         if settings.enable_nightly_backup:
-            bot.nightly_backup.start.assert_called_once()
+            mock_create_task.assert_called_once()
+            assert bot._scheduler_task is mock_task
+
+
+@pytest.mark.asyncio
+async def test_bot_on_ready_skips_scheduler_if_already_running() -> None:
+    """Test on_ready does not start a second scheduler if one is already running."""
+    bot = NightScoutBackupBot()
+
+    mock_user = MagicMock()
+    mock_user.id = 123456789
+    mock_user.__str__ = MagicMock(return_value="TestBot#1234")  # type: ignore[method-assign]
+
+    mock_guilds = [MagicMock(), MagicMock()]
+
+    # Simulate an already-running task
+    existing_task = MagicMock(spec=asyncio.Task)
+    existing_task.done.return_value = False
+    bot._scheduler_task = existing_task
+
+    with (
+        patch.object(type(bot), "user", new=mock_user),
+        patch.object(type(bot), "guilds", new=mock_guilds),
+        patch("nightscout_backup_bot.bot.asyncio.create_task") as mock_create_task,
+    ):
+        await bot.on_ready()
+
+        mock_create_task.assert_not_called()
+        assert bot._scheduler_task is existing_task
 
 
 @pytest.mark.asyncio
@@ -133,19 +150,65 @@ async def test_bot_cog_loading() -> None:
 
 @pytest.mark.asyncio
 async def test_nightly_backup_task_disabled() -> None:
-    """Test that nightly backup task respects settings."""
+    """Test that nightly backup scheduler respects the enable_nightly_backup setting."""
     bot = NightScoutBackupBot()
 
-    # If nightly backup is disabled in settings, task should not be running
-    # This is handled in on_ready, so we test that behavior
-    if not settings.enable_nightly_backup:
-        bot.nightly_backup = MagicMock()
-        bot.nightly_backup.is_running.return_value = False
+    mock_user = MagicMock()
+    mock_user.id = 123456789
+    mock_user.__str__ = MagicMock(return_value="TestBot#1234")  # type: ignore[method-assign]
+
+    mock_guilds = [MagicMock()]
+
+    with (
+        patch.object(type(bot), "user", new=mock_user),
+        patch.object(type(bot), "guilds", new=mock_guilds),
+        patch("nightscout_backup_bot.bot.settings") as mock_settings,
+        patch("nightscout_backup_bot.bot.asyncio.create_task") as mock_create_task,
+    ):
+        mock_settings.enable_nightly_backup = False
 
         await bot.on_ready()
 
-        # Should not call start if disabled
-        bot.nightly_backup.start.assert_not_called()
+        mock_create_task.assert_not_called()
+        assert bot._scheduler_task is None
+
+
+@pytest.mark.asyncio
+async def test_nightly_backup_scheduler_computes_next_run() -> None:
+    """_nightly_backup_scheduler sleeps until the next Eastern target time then runs the backup."""
+    import datetime
+
+    bot = NightScoutBackupBot()
+    bot.wait_until_ready = AsyncMock()
+    bot.nightly_backup = AsyncMock()  # type: ignore[method-assign]
+
+    # Feed a known "now" so we can assert the sleep duration
+    eastern = datetime.timezone(datetime.timedelta(hours=-4))  # EDT
+    fake_now = datetime.datetime(2026, 3, 30, 2, 30, tzinfo=eastern)  # 30 min past target
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        raise asyncio.CancelledError  # stop the loop after first iteration
+
+    with (
+        patch("nightscout_backup_bot.bot.asyncio.sleep", side_effect=fake_sleep),
+        patch("nightscout_backup_bot.bot.datetime") as mock_dt,
+        patch("nightscout_backup_bot.bot.settings") as mock_settings,
+    ):
+        mock_settings.backup_hour = 2
+        mock_settings.backup_minute = 0
+        mock_dt.datetime.now.return_value = fake_now
+        mock_dt.datetime.side_effect = lambda *a, **kw: datetime.datetime(*a, **kw)
+        mock_dt.timedelta = datetime.timedelta
+
+        with pytest.raises(asyncio.CancelledError):
+            await bot._nightly_backup_scheduler()
+
+    # 30 min past → next target is ~23.5 hours away
+    assert len(sleep_calls) == 1
+    assert 23 * 3600 < sleep_calls[0] < 24 * 3600
 
 
 @pytest.mark.asyncio
@@ -264,17 +327,6 @@ async def test_nightly_backup_no_thread_management_cog() -> None:
 
         # Backup should still complete
         bot.backup_service.execute_backup.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_before_nightly_backup() -> None:
-    """Test before_nightly_backup waits for the bot to be ready."""
-    bot = NightScoutBackupBot()
-    bot.wait_until_ready = AsyncMock()
-
-    await bot.before_nightly_backup()
-
-    bot.wait_until_ready.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Root cause:** `ZoneInfo` cannot determine the UTC offset from a bare `datetime.time` (no date = no DST context). Passing `ZoneInfo("America/New_York")` to `tasks.loop(time=...)` caused a `TypeError: can't compare offset-naive and offset-aware times` inside disnake's internal `_prepare_time_index`, killing the asyncio task before it ever fired — with no log output.

**Fix:** Replace `tasks.loop(time=...)` with a manual `asyncio.sleep` loop in `_nightly_backup_scheduler()`. On each iteration it calls `datetime.datetime.now(ZoneInfo("America/New_York"))`, which gives `ZoneInfo` a concrete date so it can resolve EST vs. EDT correctly. The next-run offset is recomputed every single night, meaning DST transitions (spring-forward in March, fall-back in November) are handled automatically without a bot restart.

**Why not just fix the UTC conversion?** An earlier commit on this branch did exactly that (`_get_backup_time_utc`), but that approach only recomputes the UTC target at module load time — a bot running continuously across a DST boundary would still be off by an hour until the next restart. This commit supersedes that approach entirely.

## Test plan

- [ ] `poetry run pytest tests/unit/test_bot.py -v` — 17 tests pass
- [ ] Deploy to production; confirm startup log shows `Nightly backup scheduler started | hour=2 | minute=0`
- [ ] Verify backup fires at 2 AM Eastern the following night

🤖 Generated with [Claude Code](https://claude.com/claude-code)